### PR TITLE
Asset should depends on YiiAsset

### DIFF
--- a/AutoNumericAsset.php
+++ b/AutoNumericAsset.php
@@ -19,4 +19,7 @@ class AutoNumericAsset extends AssetBundle
     public $js = [
         'autoNumeric.js'
     ];
+    public $depends = [
+        'yii\web\YiiAsset'
+    ];
 }


### PR DESCRIPTION
I'm getting this error.
Because jquery is loaded after autonumeric.js is loaded.

```
TypeError: $ is undefined
TypeError: jQuery(...).autoNumeric is not a function
```

adding YiiAsset on `$depends`  should fix this issue.
